### PR TITLE
Ajout de balises et attributs pour l'accessibilité de la lecture du résultat

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -164,6 +164,9 @@ label abbr {
   height: 1.5em;
 }
 
+/* Accessibility */
+.reader-only {display:none;}
+
 /* Grade colors, A is default and the only one with white letter */
 [data-type="A"] {--color-letter: #fff;}
 [data-type="B"] {--color-score: #51B84B;}

--- a/css/styles.css
+++ b/css/styles.css
@@ -164,8 +164,19 @@ label abbr {
   height: 1.5em;
 }
 
-/* Accessibility */
-.reader-only {display:none;}
+/* Accessibility. Solution by Gaël POUPARD */
+.reader-only {
+  border: 0 !important;
+	clip: rect(1px, 1px, 1px, 1px) !important;
+	-webkit-clip-path: inset(50%) !important;
+	clip-path: inset(50%) !important;
+	height: 1px !important;
+	overflow: hidden !important;
+	padding: 0 !important;
+	position: absolute !important;
+	width: 1px !important;
+  white-space: nowrap !important;
+}
 
 /* Grade colors, A is default and the only one with white letter */
 [data-type="A"] {--color-letter: #fff;}

--- a/js/app.js
+++ b/js/app.js
@@ -93,8 +93,7 @@ document.addEventListener("DOMContentLoaded", () => {
   function showEcoIndex() {
     const ecoIndex = computeEcoIndex(DOM.value, requetes.value, page.value);
 
-    results.innerHTML =
-		"<span>Votre score EcoIndex est estimé à&nbsp;:<span aria-hidden=\"false\" class=\"reader-only\">"+	ecoIndex + " soit une note de "+ getEcoIndexGrade(ecoIndex) + "</span></span>" +	"<p class=\"results_grade\"><span class=\"score\">" + ecoIndex + 	"</span> <span aria-hidden=\"true\"> / </span><span aria-hidden=\"false\" class=\"reader-only\>ce qui lui donne une note de</span> <span class=\"note\">" +	getEcoIndexGrade(ecoIndex) + "</span></p>";
+    results.innerHTML =	"<span>Votre score EcoIndex est estimé à&nbsp;:<span class=\"reader-only\">" + ecoIndex +	" soit une note de " +	getEcoIndexGrade(ecoIndex) +	"</span></span>" + "<p class=\"results_grade\" aria-hidden=\"true\"><span class=\"score\">" +	ecoIndex + "</span> / <span class=\"note\">" +	getEcoIndexGrade(ecoIndex) + "</span></p>";
 
     results.setAttribute('data-type', getEcoIndexGrade(ecoIndex));
   }

--- a/js/app.js
+++ b/js/app.js
@@ -93,7 +93,8 @@ document.addEventListener("DOMContentLoaded", () => {
   function showEcoIndex() {
     const ecoIndex = computeEcoIndex(DOM.value, requetes.value, page.value);
 
-    results.innerHTML = "Votre score EcoIndex est estimé à&nbsp;:<p class=\"results_grade\"><span class=\"score\">" + ecoIndex + "</span> / <span class=\"note\">" + getEcoIndexGrade(ecoIndex) + "</span></p>"
+    results.innerHTML =
+		"<span>Votre score EcoIndex est estimé à&nbsp;:<span aria-hidden=\"false\" class=\"reader-only\">"+	ecoIndex + " soit une note de "+ getEcoIndexGrade(ecoIndex) + "</span></span>" +	"<p class=\"results_grade\"><span class=\"score\">" + ecoIndex + 	"</span> <span aria-hidden=\"true\"> / </span><span aria-hidden=\"false\" class=\"reader-only\>ce qui lui donne une note de</span> <span class=\"note\">" +	getEcoIndexGrade(ecoIndex) + "</span></p>";
 
     results.setAttribute('data-type', getEcoIndexGrade(ecoIndex));
   }


### PR DESCRIPTION
Je propose d'englober la phrase de résultat dans un `span` (en fait, n'importe quel autre balise fonctionnera, je ne sais pas ce qui est sémantiquement plus juste.)

Et d'y ajouter une balise (ici, un `span`, mais, pareil, je n'ai pas les compétences pour jauger de la sémantique à utiliser) contenant le score. 
Un attribut `aria-hidden='false'` y est passé, et une `class` qui contient simplement un `display: none` (et non un `visibility: hidden` qui gênerait le css.).
Aussi, j'ai mis le `aria-hidden` du résultat stylisé en `true`, pour ne pas relire deux fois.

**Comportement attendu** (testé avec **_ChromeVox_**) : lecture du score à la pression du bouton _`'Lancer la simulation'`_ sans besoin de changer de section.

J'ai gardé le contenu du `results.innerHTML` en une ligne comme c'était, malgré que ça fasse une ligne très longue, je n'ai pas voulu changer ta/votre méthode.

Très bonne journée (et bravo pour ce projet très sympa !)